### PR TITLE
Fix after breaking change in Nim

### DIFF
--- a/tempfile.nim
+++ b/tempfile.nim
@@ -6,6 +6,10 @@
 import os
 import math
 
+# Since random number generator was moved to separate module:
+when not compiles(randomize()):
+  import random
+
 const
   MAX_RETRIES = 9999
   CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"


### PR DESCRIPTION
Random number generation was moved from `math` to `random`.
This PR checks if `randomize()` is present in `math`, and tries to import `random` otherwise.
Fixes #3 .
