### PR TITLE
Proper fix for directory creation

### DIFF
--- a/tempfile.nim
+++ b/tempfile.nim
@@ -62,7 +62,10 @@ proc mkdtemp*(prefix = "tmp", suffix = "", dir = ""): string =
       # A bit racy, but better than nothing
       if not path.existsDir:
         createDir(path)
-        return path
+        # In Nim 0.15.2 and older `createDir` didn't fail if `path`
+        # did already exist, but was not a directory.
+        if path.existsDir:
+          return path
     except:
       discard
   raise newException(IOError, "Unable to create temporary directory")


### PR DESCRIPTION
Changes:
- Rewrite directory creation for Nim 0.15.3+ to remove the race (guard the new logic with a `when` to preserve compatibility)
- In old directory creation branch check that the resulting path is, indeed, a directory. In 0.15.2 and older `createDir` succeeded if the _file_ with the same name existed.

See:
- Relevant changes in `os` module: https://github.com/nim-lang/Nim/commit/2f725e923e6c2288a4d8121ae667ed7425645d1a
- Comment mentioning the `createDir` bug: https://github.com/nim-lang/Nim/issues/4917#issuecomment-255522530
- Issue this is supposed to fix (previously closed because of a temporary fix): #5
